### PR TITLE
Use include_once instead of require_once for autoloader

### DIFF
--- a/php/util.php
+++ b/php/util.php
@@ -12,7 +12,7 @@ spl_autoload_register(function ($class)
 	$arr = explode('\\',$class);
 	$class = end($arr);
 	
-	require_once 'utility/'. strtolower($class). '.php';
+	include_once 'utility/'. strtolower($class). '.php';
 });
 
 // Fixes quotations if php verison is less than 5.4


### PR DESCRIPTION
Third party plugins which implement their own autoloader may throw an error with require_once. It's more appropriate to throw a warning in this situation.